### PR TITLE
changed the yaml dependency

### DIFF
--- a/store.go
+++ b/store.go
@@ -12,7 +12,7 @@ import (
 	"runtime"
 
 	"github.com/BurntSushi/toml"
-	"github.com/go-yaml/yaml"
+	"gopkg.in/yaml.v2"
 )
 
 // MarshalFunc is any marshaler.


### PR DESCRIPTION
This change is required in order for the 'dep' tool to manage its dependencies correctly. The yaml package is provided by gopkg.in instead of github.com (this seems like a quirk to me; it would better to use tags and keep the code on github IMHO but the yaml developers didn't do this).