### PR TITLE
Added go.mod support, fixed a bug and made a simple addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Store
 >Store is a dead simple configuration manager for Go applications.
 
+NOTE:
+This fork is maintained by `karanveersp` and includes a bugfix, some extra comments, and a new public function to get the config directory path. This is an updated version of the library made available at [github.com/tucnak/store](https://github.com/tucnak/store). If and when my pull request is merged into the original repo, it is recommended you use that instead of my fork.
+
+
 [![GoDoc](https://godoc.org/github.com/karanveersp/store?status.svg)](https://godoc.org/github.com/karanveersp/store)
 
 I didn't like existing configuration management solutions like [globalconf](https://github.com/rakyll/globalconf), [tachyon](https://github.com/vektra/tachyon) or [viper](https://github.com/spf13/viper). First two just don't feel right and viper, imo, a little overcomplicated—definitely offering too much for small things. Store supports either JSON, TOML or YAML out-of-the-box and lets you register practically any other configuration format. It persists all of your configurations in either $XDG_CONFIG_HOME or $HOME on Linux and in %APPDATA%

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Store
 >Store is a dead simple configuration manager for Go applications.
 
-[![GoDoc](https://godoc.org/github.com/tucnak/store?status.svg)](https://godoc.org/github.com/tucnak/store)
+[![GoDoc](https://godoc.org/github.com/karanveersp/store?status.svg)](https://godoc.org/github.com/karanveersp/store)
 
 I didn't like existing configuration management solutions like [globalconf](https://github.com/rakyll/globalconf), [tachyon](https://github.com/vektra/tachyon) or [viper](https://github.com/spf13/viper). First two just don't feel right and viper, imo, a little overcomplicated—definitely offering too much for small things. Store supports either JSON, TOML or YAML out-of-the-box and lets you register practically any other configuration format. It persists all of your configurations in either $XDG_CONFIG_HOME or $HOME on Linux and in %APPDATA%
 on Windows.
@@ -14,7 +14,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/tucnak/store"
+	"github.com/karanveersp/store"
 )
 
 func init() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tucnak/store
+module github.com/karanveersp/store
 
 go 1.20
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/tucnak/store
+
+go 1.20
+
+require (
+	github.com/BurntSushi/toml v1.2.1
+	gopkg.in/yaml.v2 v2.4.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
+github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/store.go
+++ b/store.go
@@ -209,10 +209,3 @@ func buildPlatformPath(path string) string {
 	applicationDir := getApplicationDirPath(envPath, sep)
 	return fmt.Sprintf("%s%s%s", applicationDir, sep, path)
 }
-
-func pathExists(path string) bool {
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		return true
-	}
-	return false
-}

--- a/store_test.go
+++ b/store_test.go
@@ -44,9 +44,9 @@ func TestSaveLoad(t *testing.T) {
 	settings := Settings{
 		Age: 42,
 		Cats: []Cat{
-			Cat{"Rudolph", true},
-			Cat{"Patrick", false},
-			Cat{"Jeremy", true},
+			{"Rudolph", true},
+			{"Patrick", false},
+			{"Jeremy", true},
 		},
 		RandomString: "gophers are gonna conquer the world",
 	}
@@ -59,7 +59,7 @@ func TestSaveLoad(t *testing.T) {
 		return
 	}
 
-	defer os.Remove(buildPlatformPath(settingsFile))
+	defer os.RemoveAll(GetApplicationDirPath())
 
 	var newSettings Settings
 


### PR DESCRIPTION
Hi,
This library is really cool and useful so I wanted to understand how it worked. While reading the source, I was able to make some general refactors such as:

- Adding go.mod support
- Replacing `interface{}` with `any` which is an alias to `interface{}`. 
- Fixing a bug where `err` was being returned instead of `innerErr`.
- Adding a public function `GetApplicationDirPath` which returns the path to platform-dependent application configuration directory. This is useful if the user of the library wants to manipulate it and needs easy access to that parent folder of the config for deleting it, or backing it up somewhere, etc. 

I updated the test to use `GetApplicationDirPath` to verify it works. 